### PR TITLE
Refactor RasterIndex internals (do not wrap PandasIndex)

### DIFF
--- a/src/rasterix/raster_index.py
+++ b/src/rasterix/raster_index.py
@@ -331,11 +331,9 @@ class RasterIndex(Index):
     - **Rectilinear grids**: Uses separate 1D indexes for independent x/y axes,
       enabling more efficient slicing operations.
 
-    Parameters
-    ----------
-    indexes : Mapping[WrappedIndexCoords, WrappedIndex]
-        Dictionary mapping coordinate names to their corresponding index objects.
-        Keys are either single coordinate names or tuples for coupled coordinates.
+    Do not use :py:meth:`~rasterix.RasterIndex.__init__` directly. Instead use
+    :py:meth:`~rasterix.RasterIndex.from_transform` or
+    :py:func:`~rasterix.assign_index`.
 
     Attributes
     ----------

--- a/src/rasterix/raster_index.py
+++ b/src/rasterix/raster_index.py
@@ -399,7 +399,7 @@ class RasterIndex(Index):
                 index[YAXIS].axis_transform.coord_name,
             )
         else:
-            raise ValueError("invalid index")
+            raise ValueError(f"Could not create RasterIndex. Received invalid index {index!r}")
 
         self._index = index
 

--- a/src/rasterix/raster_index.py
+++ b/src/rasterix/raster_index.py
@@ -691,6 +691,7 @@ def as_compatible_bboxes(*indexes: RasterIndex, concat_dim: Hashable | None) -> 
         if all(o == off_x[0] for o in off_x[1:]) and all(o == off_y[0] for o in off_y[1:]):
             raise ValueError("Attempting to concatenate arrays with same transform along X or Y.")
 
+    # TODO: get concat x or y axis dimension name from the index (not hard-coded)
     if concat_dim == "x":
         if any(off_y[0] != o for o in off_y[1:]):
             raise ValueError("offsets must be identical in X when concatenating along Y")

--- a/src/rasterix/raster_index.py
+++ b/src/rasterix/raster_index.py
@@ -370,7 +370,7 @@ class RasterIndex(Index):
 
     """
 
-    _index: CoordinateTransformIndex | tuple[AxisAffineTransformIndex, AxisAffineTransformIndex]
+    _index: WrappedIndex
     _axis_independent: bool
     _xy_shape: tuple[int, int]
     _xy_dims: tuple[str, str]

--- a/src/rasterix/raster_index.py
+++ b/src/rasterix/raster_index.py
@@ -715,15 +715,17 @@ def as_compatible_bboxes(*indexes: RasterIndex, concat_dim: Hashable | None) -> 
         if all(o == off_x[0] for o in off_x[1:]) and all(o == off_y[0] for o in off_y[1:]):
             raise ValueError("Attempting to concatenate arrays with same transform along X or Y.")
 
-    # TODO: get concat x or y axis dimension name from the index (not hard-coded)
-    if concat_dim == "x":
+    # note: Xarray alignment already ensures that the indexes dimensions are compatible.
+    x_dim, y_dim = indexes[0].xy_dims
+
+    if concat_dim == x_dim:
         if any(off_y[0] != o for o in off_y[1:]):
             raise ValueError("offsets must be identical in X when concatenating along Y")
         if any(a != b for a, b in zip(off_x, expected_off_x)):
             raise ValueError(
                 f"X offsets are incompatible. Provided offsets {off_x}, expected offsets: {expected_off_x}"
             )
-    elif concat_dim == "y":
+    elif concat_dim == y_dim:
         if any(off_x[0] != o for o in off_x[1:]):
             raise ValueError("offsets must be identical in X when concatenating along Y")
 

--- a/src/rasterix/raster_index.py
+++ b/src/rasterix/raster_index.py
@@ -382,7 +382,7 @@ class RasterIndex(Index):
             and isinstance(idx_keys[0], tuple)
             and isinstance(idx_vals[0], CoordinateTransformIndex)
         )
-        axis_independent = len(indexes) in (1, 2) and all(
+        axis_independent = len(indexes) == 2 and all(
             isinstance(idx, AxisAffineTransformIndex) for idx in idx_vals
         )
         assert axis_dependent ^ axis_independent

--- a/src/rasterix/raster_index.py
+++ b/src/rasterix/raster_index.py
@@ -619,6 +619,13 @@ class RasterIndex(Index):
         return self._new_with_bbox(new_bbox)
 
     def reindex_like(self, other: Self, method=None, tolerance=None) -> dict[Hashable, Any]:
+        if self._xy_indexes is not None:
+            x_dim = self._xy_indexes[0].axis_transform.dim
+            y_dim = self._xy_indexes[1].axis_transform.dim
+        else:
+            assert self._index is not None
+            x_dim, y_dim = cast(AffineTransform, self._index.transform).xy_dims
+
         affine = self.transform()
         ours, theirs = as_compatible_bboxes(self, other, concat_dim=None)
         inter = bbox_intersection([ours, theirs])
@@ -631,11 +638,11 @@ class RasterIndex(Index):
         tol: float = 0.01
 
         indexers = {}
-        indexers["x"] = get_indexer(
-            theirs.left, ours.left, inter.left, inter.right, spacing=dx, tol=tol, size=other._shape["x"]
+        indexers[x_dim] = get_indexer(
+            theirs.left, ours.left, inter.left, inter.right, spacing=dx, tol=tol, size=other._shape[x_dim]
         )
-        indexers["y"] = get_indexer(
-            theirs.top, ours.top, inter.top, inter.bottom, spacing=dy, tol=tol, size=other._shape["y"]
+        indexers[y_dim] = get_indexer(
+            theirs.top, ours.top, inter.top, inter.bottom, spacing=dy, tol=tol, size=other._shape[y_dim]
         )
         return indexers
 

--- a/tests/test_raster_index.py
+++ b/tests/test_raster_index.py
@@ -25,6 +25,21 @@ def test_rectilinear():
     assert da_raster_index.equals(da_no_raster_index)
 
 
+def test_raster_index_properties():
+    index1 = RasterIndex.from_transform(Affine.identity(), 12, 10)
+    assert index1.xy_shape == (12, 10)
+    assert index1.xy_dims == ("x", "y")
+    assert index1.xy_coord_names == ("x", "y")
+
+    index2 = RasterIndex.from_transform(Affine.identity(), 12, 10, x_dim="x_", y_dim="y_")
+    assert index2.xy_dims == ("x_", "y_")
+
+    index3 = RasterIndex.from_transform(Affine.rotation(45.0), 12, 10)
+    assert index3.xy_shape == (12, 10)
+    assert index3.xy_dims == ("x", "y")
+    assert index3.xy_coord_names == ("xc", "yc")
+
+
 # TODO: parameterize over
 # 1. y points up;
 # 2. y points down


### PR DESCRIPTION
Closes #40.

This PR limits `RasterIndex._wrapped_indexes` to these two exact cases:

- `{("x", "y"): CoordinateTransformIndex}`
-  `{"x": AxisAffineTransformIndex, "y": AxisAffineTransformIndex}`

This makes things much easier.